### PR TITLE
feat: implement caching mechanism for translation results

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "express": "^4.21.2",
         "express-validator": "^7.3.1",
         "fzstd": "^0.1.1",
+        "lru-cache": "^11.2.4",
         "swagger-ui-express": "^5.0.1",
       },
       "devDependencies": {
@@ -311,7 +312,7 @@
 
     "lodash": ["lodash@4.17.21", "https://registry.npmmirror.com/lodash/-/lodash-4.17.21.tgz", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
 
-    "lru-cache": ["lru-cache@10.4.3", "https://registry.npmmirror.com/lru-cache/-/lru-cache-10.4.3.tgz", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+    "lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "https://registry.npmmirror.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -456,6 +457,8 @@
     "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-7.1.2.tgz", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "path-scurry/lru-cache": ["lru-cache@10.4.3", "https://registry.npmmirror.com/lru-cache/-/lru-cache-10.4.3.tgz", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "send/ms": ["ms@2.1.3", "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "express": "^4.21.2",
     "express-validator": "^7.3.1",
     "fzstd": "^0.1.1",
+    "lru-cache": "^11.2.4",
     "swagger-ui-express": "^5.0.1"
   },
   "engines": {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -19,6 +19,7 @@ export interface Config {
   logConsole: boolean;
   maxLengthBreak: number;
   checkUpdate: boolean;
+  cacheSize: number;
 }
 
 let globalConfig: Config | null = null;
@@ -125,6 +126,8 @@ export function getConfig(): Config {
     logConsole: getBool('--log-console', 'MT_LOG_CONSOLE', true),
 
     checkUpdate: getBool('--check-update', 'MT_CHECK_UPDATE', true),
+
+	cacheSize: getInt('--cache-size', 'MT_CACHE_SIZE', 0),
   };
 
   return globalConfig;

--- a/src/services/engine.ts
+++ b/src/services/engine.ts
@@ -8,6 +8,7 @@ import wasmPath from '@/lib/bergamot/bergamot-translator.wasm' with { type: 'fil
 import * as logger from '@/logger/index.js';
 import * as models from '@/models/index.js';
 import { detectLanguage, detectMultipleLanguages } from './detector.js';
+import { readCacheTranslateWithPivot, writeCacheTranslateWithPivot } from '@/utils/cache.js';
 
 interface EngineInfo {
   engine: TranslationEngine;
@@ -187,6 +188,24 @@ async function translateSegment(
 }
 
 export async function translateWithPivot(
+  fromLang: string,
+  toLang: string,
+  text: string,
+  isHTML: boolean = false
+): Promise<string> {
+
+  const cache = readCacheTranslateWithPivot([fromLang, toLang, text, isHTML]);
+  if (cache !== null) {
+	logger.debug(`readCacheTranslateWithPivot: ${fromLang} -> ${toLang}, text length: ${text.length}, isHTML: ${isHTML}`);
+    return cache;
+  }
+
+  const result = await originalTranslateWithPivot(fromLang, toLang, text, isHTML);
+  writeCacheTranslateWithPivot(result, [fromLang, toLang, text, isHTML]);
+  return result;
+}
+
+export async function originalTranslateWithPivot(
   fromLang: string,
   toLang: string,
   text: string,

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,42 @@
+import crypto from 'crypto';
+import { LRUCache } from 'lru-cache';
+import { getConfig } from '@/config/index.js';
+
+const config = getConfig();
+
+const cache = new LRUCache({
+  max: config.cacheSize || 200,
+});
+
+function getCacheKey(...args: any[]): string {
+  let keyStr = args.join('_');
+  keyStr += `_${keyStr.length}`;
+  return crypto.createHash('sha1').update(keyStr).digest('hex');
+}
+
+export function readCacheTranslateWithPivot(args: any[]): string | null {
+
+  if (config.cacheSize === 0) {
+    return null;
+  }
+
+  const key = getCacheKey(...args);
+
+  const cacheEntry = cache.get(key);
+  if (cacheEntry) {
+    return cacheEntry as string;
+  }
+  
+  return null;
+}
+
+export function writeCacheTranslateWithPivot(result: string, args: any[]): void {
+
+  if (config.cacheSize === 0) {
+    return;
+  }
+
+  const key = getCacheKey(...args);
+
+  cache.set(key, result);
+}


### PR DESCRIPTION
实现翻译缓存.

- 使用 [lru-cache](https://www.npmjs.com/package/lru-cache) 库实现内存缓存和自动清理旧缓存
- 添加了配置 `--cache-size` 和 `MT_CACHE_SIZE` 指定缓存数量, 默认为 0 表示不使用缓存

当命中缓存时会发出日志:
```
[DEBUG] 2026-01-05 03:50:00.684 readCacheTranslateWithPivot: auto -> zh-Hans, text length: 5, isHTML: false
```

lru-cache 的机制会删除最近使用最少的项的缓存对象

close #105