### PR TITLE
fix: history component has no scrollbar

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -110,6 +110,10 @@
   --sidebar-ring: oklch(0.556 0 0);
 }
 
+[data-slot="scroll-area"] {
+  overflow-y: auto;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;


### PR DESCRIPTION
修复历史记录无法滚动.

我只会原生开发, 这在 React 中可能不是最佳实践, 但是它能起作用.